### PR TITLE
Bump onecodex version, support new report generation API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -173,6 +173,7 @@ RUN mkdir /opt/onecodex/
 COPY notebook/notebook.html /usr/local/lib/python3.6/site-packages/notebook/templates
 COPY notebook/override.css /usr/local/lib/python3.6/site-packages/notebook/static/notebook/css
 COPY notebook/onecodex.js /home/$NB_USER/.jupyter/custom/
+COPY notebook/one-codex-spinner.svg /home/$NB_USER/.jupyter/custom/
 
 # Add local files
 COPY notebook/jupyter_notebook_config.py /home/$NB_USER/.jupyter/

--- a/Dockerfile
+++ b/Dockerfile
@@ -179,7 +179,8 @@ COPY notebook/token_notebook.py /usr/local/bin/token_notebook.py
 RUN chmod +x /usr/local/bin/token_notebook.py
 
 # Install One Codex Python lib
-RUN pip install --no-cache onecodex[all]==0.3.1
+#RUN pip install --no-cache onecodex[all]==0.4.0
+RUN git clone https://github.com/onecodex/onecodex && cd onecodex && pip install .[all]
 
 # Finally fix permissions on everything
 # See https://github.com/jupyter/docker-stacks/issues/188

--- a/Dockerfile
+++ b/Dockerfile
@@ -172,11 +172,17 @@ RUN mkdir /opt/onecodex/
 # COPY install/* /opt/onecodex/
 COPY notebook/notebook.html /usr/local/lib/python3.6/site-packages/notebook/templates
 COPY notebook/override.css /usr/local/lib/python3.6/site-packages/notebook/static/notebook/css
+COPY notebook/onecodex.js /home/$NB_USER/.jupyter/custom/
 
 # Add local files
 COPY notebook/jupyter_notebook_config.py /home/$NB_USER/.jupyter/
 COPY notebook/token_notebook.py /usr/local/bin/token_notebook.py
 RUN chmod +x /usr/local/bin/token_notebook.py
+
+# Add patch to jupyter notebook for export to One Codex document portal
+COPY notebook/notebook.patch /usr/local/lib/python3.6/site-packages/notebook
+RUN cd /usr/local/lib/python3.6/site-packages/notebook \
+    && patch -p0 < notebook.patch
 
 # Install One Codex Python lib
 #RUN pip install --no-cache onecodex[all]==0.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,23 +13,23 @@ USER root
 # features (e.g., download as all possible file formats)
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -yq --no-install-recommends \
-    wget \
+    apt-transport-https \
+    build-essential \
     bzip2 \
     ca-certificates \
-    gnupg \
-    apt-transport-https \
-    sudo \
-    locales \
-    git \
-    vim \
-    build-essential \
-    python-dev \
-    unzip \
-    fonts-dejavu \
-    gfortran \
-    gcc \
     cmake \
     curl \
+    fonts-dejavu \
+    gcc \
+    gfortran \
+    git \
+    gnupg \
+    locales \
+    python-dev \
+    sudo \
+    unzip \
+    vim \
+    wget \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -127,9 +127,6 @@ RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - 
     && echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
 RUN apt-get update && apt-get install -yq --no-install-recommends google-chrome-stable chromedriver
 
-# Dependencies for weasyprint
-RUN apt-get update && apt-get install -yq --no-install-recommends libffi6 libcairo2 libpango1.0
-
 # Install R and some basic packages
 RUN apt-get update && apt-get install -yq --no-install-recommends \
     r-base \
@@ -151,6 +148,17 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 # This lets us select R from inside the notebook
 RUN echo "install.packages(\"IRkernel\", repos=\"https://cran.rstudio.com\")" | R --no-save
 RUN echo "IRkernel::installspec()" | R --no-save
+
+# Dependencies for weasyprint. Known bugs on libcairo < 1.15.4. Must pull from debian-buster to get 1.16
+RUN echo "deb http://deb.debian.org/debian buster main" >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -yq --no-install-recommends \
+    libffi6 \
+    libcairo2 \
+    libpango1.0.0 \
+    fonts-uralic \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Configure container startup
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -173,10 +173,6 @@ RUN chmod +x /usr/local/bin/token_notebook.py
 # Install One Codex Python lib
 RUN pip install --no-cache onecodex[all]==0.3.1
 
-# Install forked ipyvega that opens links in a new window/tab
-# See https://github.com/onecodex/onecodex/issues/137
-RUN pip install -U git+https://github.com/onecodex/ipyvega.git@target-blank
-
 # Finally fix permissions on everything
 # See https://github.com/jupyter/docker-stacks/issues/188
 RUN chown -R $NB_USER:root /home/$NB_USER && chmod -R u+w,g+w /home/$NB_USER

--- a/Dockerfile
+++ b/Dockerfile
@@ -186,8 +186,7 @@ RUN cd /usr/local/lib/python3.6/site-packages/notebook \
     && patch -p0 < notebook.patch
 
 # Install One Codex Python lib
-#RUN pip install --no-cache onecodex[all]==0.4.0
-RUN git clone https://github.com/onecodex/onecodex && cd onecodex && pip install .[all]
+RUN pip install --no-cache onecodex[all]==0.4.0
 
 # Finally fix permissions on everything
 # See https://github.com/jupyter/docker-stacks/issues/188

--- a/notebook/jupyter_nbconvert_config.py
+++ b/notebook/jupyter_nbconvert_config.py
@@ -1,0 +1,15 @@
+c = get_config()
+
+# Prefer JavaScript over SVG when exporting notebooks as HTML--keeps figures interactive
+c.NbConvertBase.display_data_priority = [
+    'application/vnd.jupyter.widget-state+json',
+    'application/vnd.jupyter.widget-view+json',
+    'application/javascript',
+    'image/svg+xml',
+    'text/html',
+    'text/markdown',
+    'text/latex',
+    'image/png',
+    'image/jpeg',
+    'text/plain'
+]

--- a/notebook/jupyter_notebook_config.py
+++ b/notebook/jupyter_notebook_config.py
@@ -12,12 +12,12 @@ c.NotebookApp.ip = '0.0.0.0'
 c.NotebookApp.port = 8888
 c.NotebookApp.open_browser = False
 
-# Prefer SVG over JavaScript when exporting notebooks as HTML
+# Prefer JavaScript over SVG when exporting notebooks as HTML--keeps figures interactive
 c.NbConvertBase.display_data_priority = [
     'application/vnd.jupyter.widget-state+json',
     'application/vnd.jupyter.widget-view+json',
-    'image/svg+xml',
     'application/javascript',
+    'image/svg+xml',
     'text/html',
     'text/markdown',
     'text/latex',

--- a/notebook/notebook.html
+++ b/notebook/notebook.html
@@ -92,7 +92,7 @@ data-notebook-path="{{notebook_path | urlencode}}"
                             <ul id="download_menu" class="dropdown-menu">
                                 <li id="download_ipynb"><a href="#">{% trans %}Notebook (.ipynb){% endtrans %}</a></li>
                                 <li id="download_html"><a href="#">{% trans %}HTML (.html){% endtrans %}</a></li>
-                                <!-- <li id="download_onecodex_pdf"><a href="#">{% trans %}PDF Report (.pdf){% endtrans %}</a></li> -->
+                                <li id="download_onecodex_pdf"><a href="#">{% trans %}PDF Report (.pdf){% endtrans %}</a></li>
                                 <!-- <li id="download_onecodex_doc"><a href="#">{% trans %}Export to One Codex (.pdf){% endtrans %}</a></li> -->
                             </ul>
                         </li>

--- a/notebook/notebook.html
+++ b/notebook/notebook.html
@@ -93,9 +93,9 @@ data-notebook-path="{{notebook_path | urlencode}}"
                                 <li id="download_ipynb"><a href="#">{% trans %}Notebook (.ipynb){% endtrans %}</a></li>
                                 <li id="download_html"><a href="#">{% trans %}HTML (.html){% endtrans %}</a></li>
                                 <li id="download_onecodex_pdf"><a href="#">{% trans %}PDF Report (.pdf){% endtrans %}</a></li>
-                                <!-- <li id="download_onecodex_doc"><a href="#">{% trans %}Export to One Codex (.pdf){% endtrans %}</a></li> -->
                             </ul>
                         </li>
+                        <li id="one_codex_export"><a href="#" onClick="require(['/custom/onecodex.js'], (ocx) => { ocx.ExportModal('report.pdf'); })">Export to One Codex (.pdf)</a></li>
                     </ul>
                 </li>
                 <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">{% trans %}Edit{% endtrans %}</a>

--- a/notebook/notebook.html
+++ b/notebook/notebook.html
@@ -93,9 +93,14 @@ data-notebook-path="{{notebook_path | urlencode}}"
                                 <li id="download_ipynb"><a href="#">{% trans %}Notebook (.ipynb){% endtrans %}</a></li>
                                 <li id="download_html"><a href="#">{% trans %}HTML (.html){% endtrans %}</a></li>
                                 <li id="download_onecodex_pdf"><a href="#">{% trans %}PDF Report (.pdf){% endtrans %}</a></li>
+                                <li id="download_onecodex_html"><a href="#">{% trans %}HTML Report (.html){% endtrans %}</a></li>
                             </ul>
                         </li>
-                        <li id="one_codex_export"><a href="#" onClick="require(['/custom/onecodex.js'], (ocx) => { ocx.ExportModal('report.pdf'); })">Export to One Codex (.pdf)</a></li>
+                        <li id="one_codex_export">
+                            <a href="#" onClick="require(['/custom/onecodex.js'], (ocx) => { ocx.ExportModal('report.pdf'); })">
+                                Export to One Codex (.pdf)
+                            </a>
+                        </li>
                     </ul>
                 </li>
                 <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">{% trans %}Edit{% endtrans %}</a>

--- a/notebook/notebook.html
+++ b/notebook/notebook.html
@@ -93,7 +93,7 @@ data-notebook-path="{{notebook_path | urlencode}}"
                                 <li id="download_ipynb"><a href="#">{% trans %}Notebook (.ipynb){% endtrans %}</a></li>
                                 <li id="download_html"><a href="#">{% trans %}HTML (.html){% endtrans %}</a></li>
                                 <li id="download_onecodex_pdf"><a href="#">{% trans %}PDF Report (.pdf){% endtrans %}</a></li>
-                                <li id="download_onecodex_html"><a href="#">{% trans %}HTML Report (.html){% endtrans %}</a></li>
+                                <li id="download_onecodex_html" style="display: none"><a href="#">{% trans %}HTML Report (.html){% endtrans %}</a></li>
                             </ul>
                         </li>
                         <li id="one_codex_export">

--- a/notebook/notebook.patch
+++ b/notebook/notebook.patch
@@ -1,0 +1,12 @@
+--- nbconvert/handlers.py	2019-02-07 16:40:43.000000000 -0800
++++ nbconvert/handlers.py	2019-02-07 16:40:32.000000000 -0800
+@@ -116,7 +116,8 @@
+         resource_dict = {
+             "metadata": {
+                 "name": nb_title,
+-                "modified_date": mod_date
++                "modified_date": mod_date,
++                "one_codex_doc_portal_filename": self.get_argument('one_codex_doc_portal_filename', None)
+             },
+             "config_dir": self.application.settings['config_dir']
+         }

--- a/notebook/one-codex-spinner.svg
+++ b/notebook/one-codex-spinner.svg
@@ -1,0 +1,154 @@
+<svg id="loading-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 112 112">
+  <style type="text/css">
+    g.logo {
+      -webkit-transform: scale(0.75);
+      transform: scale(0.75);
+    }
+    #loading-icon-svg {
+      width: 112px;
+      height: 112px;
+    }
+    #loading-icon-svg path {
+      stroke-dasharray: 300;
+      stroke-dashoffset: 300;
+      stroke-width: 13px;
+      fill-opacity: 0;
+      fill-rule: nonzero;
+      stroke-linejoin: miter;
+      stroke-linecap: square;
+    }
+    #loading-icon-svg path.background-logo-path {
+      stroke-dashoffset: 0;
+      stroke-opacity: 0.8;
+    }
+    #background-half-logo1 {
+      stroke: #f7f6ef;
+    }
+    #background-half-logo2 {
+      stroke: #f3f3ee;
+    }
+    #half-logo1 {
+      stroke: #bbd8d3;
+      -webkit-animation: 6s linear infinite normal loading-animation-1;
+      -moz-animation: 6s linear infinite normal loading-animation-1;
+      animation: 6s linear infinite normal loading-animation-1;
+    }
+    #half-logo2 {
+      stroke: #9fb9b9;
+      -webkit-animation: 6s linear infinite normal loading-animation-2;
+      -moz-animation: 6s linear infinite normal loading-animation-2;
+      animation: 6s linear infinite normal loading-animation-2;
+    }
+    @keyframes loading-animation-1 {
+      0% {
+        stroke-dashoffset: 300;
+      }
+      25% {
+        stroke-dashoffset: 0;
+      }
+      50% {
+        stroke-dashoffset: 0;
+      }
+      75% {
+        stroke-dashoffset: -300;
+      }
+      100% {
+        stroke-dashoffset: -300;
+      }
+    }
+    @keyframes loading-animation-2 {
+      0% {
+        stroke-dashoffset: 300;
+      }
+      23% {
+        stroke-dashoffset: 300;
+      }
+      50% {
+        stroke-dashoffset: 0;
+      }
+      73% {
+        stroke-dashoffset: 0;
+      }
+      100% {
+        stroke-dashoffset: -300;
+      }
+    }
+    @-moz-keyframes loading-animation-1 {
+      0% {
+        stroke-dashoffset: 300;
+      }
+      25% {
+        stroke-dashoffset: 0;
+      }
+      50% {
+        stroke-dashoffset: 0;
+      }
+      75% {
+        stroke-dashoffset: -300;
+      }
+      100% {
+        stroke-dashoffset: -300;
+      }
+    }
+    @-moz-keyframes loading-animation-2 {
+      0% {
+        stroke-dashoffset: 300;
+      }
+      23% {
+        stroke-dashoffset: 300;
+      }
+      50% {
+        stroke-dashoffset: 0;
+      }
+      73% {
+        stroke-dashoffset: 0;
+      }
+      100% {
+        stroke-dashoffset: -300;
+      }
+    }
+    @-webkit-keyframes loading-animation-1 {
+      0% {
+        stroke-dashoffset: 300;
+      }
+      25% {
+        stroke-dashoffset: 0;
+      }
+      50% {
+        stroke-dashoffset: 0;
+      }
+      75% {
+        stroke-dashoffset: 0;
+      }
+      100% {
+        stroke-dashoffset: 300;
+      }
+    }
+    @-webkit-keyframes loading-animation-2 {
+      0% {
+        stroke-dashoffset: 300;
+      }
+      23% {
+        stroke-dashoffset: 300;
+      }
+      50% {
+        stroke-dashoffset: 0;
+      }
+      77% {
+        stroke-dashoffset: 300;
+      }
+      100% {
+        stroke-dashoffset: 300;
+      }
+    }
+  </style>
+  <g class="logo">
+    <clipPath id="logo-clip">
+      <path d="m 75,60 v -60 h 55 v 85 h -55 v 65 h -60 v -80 h 50 Z"></path>
+    </clipPath>
+    <path id="background-half-logo2" transform="translate(0, 150)scale(1,-1)" d="m 75,50 l 45,-33 v 26 l -90,64 v 26 l 45,-33" clip-path="url(#logo-clip)" class="background-logo-path"></path>
+    <path id="background-half-logo1" d="m 75,50 l 45,-33 v 26 l -90,64 v 26 l 45,-33" clip-path="url(#logo-clip)" class="background-logo-path"></path>
+    <path id="half-logo2" transform="translate(0, 150)scale(1,-1)" d="m 75,50 l 45,-33 v 26 l -90,64 v 26 l 45,-33" clip-path="url(#logo-clip)"></path>
+    <path id="half-logo1" d="m 75,50 l 45,-33 v 26 l -90,64 v 26 l 45,-33" clip-path="url(#logo-clip)"></path>
+  </g>
+</svg>

--- a/notebook/onecodex.js
+++ b/notebook/onecodex.js
@@ -1,0 +1,109 @@
+define([
+  'base/js/utils',
+  'base/js/dialog'
+], function(utils, dialog) {
+  return {
+    ExportModal: (default_file_name) => {
+      const ONE_CODEX_DOCS_URL = 'http://localhost:5000/documents';
+
+      var formGroup = document.createElement('div');
+      formGroup.className = 'form-group';
+
+      var alertBox = document.createElement('div');
+      alertBox.className = 'hidden';
+      formGroup.appendChild(alertBox);
+
+      var nameLabel = document.createElement('label');
+      nameLabel.for = 'pdf-report-filename';
+      nameLabel.innerHTML = 'Choose a filename for this PDF report';
+      formGroup.appendChild(nameLabel);
+
+      var nameInput = document.createElement('input');
+      nameInput.id = 'pdf-report-filename';
+      nameInput.type = 'text';
+      nameInput.className = 'form-control';
+      nameInput.value = default_file_name;
+      formGroup.appendChild(nameInput);
+
+      var d = dialog.modal({
+        title: 'Export PDF report to One Codex Document Portal',
+        body: formGroup,
+        keyboard_manager: IPython.keyboard_manager,
+        default_button: 'Save',
+        buttons: {
+          'Save': {
+            'id': 'one-codex-save-button',
+            'class': 'btn-primary',
+            'click': () => {
+              alertBox.innerHTML = '';
+              alertBox.className = 'hidden';
+
+              if (nameInput.value === '' || nameInput.value.endsWith('.pdf') !== true) {
+                alertBox.innerHTML = 'Please specify a valid filename ending in .pdf.';
+                alertBox.className = 'alert alert-danger';
+                return false;
+              } else if (nameInput.value.length > 100) {
+                alertBox.innerHTML = 'Filenames must be less than 100 characters long.';
+                alertBox.className = 'alert alert-danger';
+                return false;
+              }
+
+              var notebook_path = utils.encode_uri_components(IPython.notebook.notebook_path);
+              var url = utils.url_path_join(
+                IPython.menubar.base_url,
+                'nbconvert',
+                'onecodex_doc',
+                notebook_path
+              ) + '?one_codex_doc_portal_filename=' + nameInput.value + '&download=false';
+
+              // disable elements while awaiting response
+              document.getElementById('pdf-report-filename').readOnly = true;
+              document.getElementById('one-codex-save-button').disabled = true;
+              alertBox.innerHTML = '<img src="https://app.onecodex.com/images/site-images/spinner.gif" ' +
+                'width="25px">&nbsp;&nbsp; Preparing report and uploading. This may take a minute.';
+              alertBox.className = 'alert alert-info';
+
+              var xhr = new XMLHttpRequest();
+              xhr.open('GET', url);
+              xhr.onload = () => {
+                if (xhr.status === 500) {
+                    alertBox.innerHTML = 'Notebook returned 500 error. Please contact help@onecodex.com for assistance.';
+                    alertBox.className = 'alert alert-danger';
+                    document.getElementById('pdf-report-filename').readOnly = false;
+                    document.getElementById('one-codex-save-button').disabled = false;
+                } else {
+                  try {
+                    var resp_json = JSON.parse(xhr.responseText);
+                  } catch(e) {
+                    var resp_json = {
+                      'status': 500,
+                      'message': 'Unspecified error. Please contact help@onecodex.com for assistance.'
+                    }
+                  }
+
+                  if (resp_json['status'] === 500) {
+                    alertBox.innerHTML = 'Upload failed. The server said:<br><br>' + resp_json['message'];
+                    alertBox.className = 'alert alert-danger';
+                    document.getElementById('pdf-report-filename').readOnly = false;
+                    document.getElementById('one-codex-save-button').disabled = false;
+                  } else {
+                    alertBox.innerHTML = 'Export successful! View the report here: <a href="' + 
+                      ONE_CODEX_DOCS_URL + '" target="_blank" class="alert-link">Documents Portal</a>';
+                    alertBox.className = 'alert alert-success';
+                    document.getElementById('one-codex-save-button').className = 'hidden';
+                    document.getElementById('one-codex-cancel-button').innerHTML = 'Return to Notebook';
+                  }
+                }
+              };
+              xhr.send();
+            }
+          },
+          'Cancel': {
+            'id': 'one-codex-cancel-button',
+            'class': 'btn'
+          }
+        }
+      });
+    }
+  }
+});

--- a/notebook/onecodex.js
+++ b/notebook/onecodex.js
@@ -5,6 +5,13 @@ define([
   return {
     ExportModal: (default_file_name) => {
       const ONE_CODEX_DOCS_URL = 'https://app.onecodex.com/documents';
+      const SPINNER_SVG_URL = '/custom/one-codex-spinner.svg';
+
+      var makeSpinnerSVG = (alertMsg) => {
+        return `<table width="100%"><tr><td width="10%" style="padding: 5px">
+                <object data="${SPINNER_SVG_URL}" type="image/svg+xml" width="50px" height="50px" />
+                </td><td width="90%">${alertMsg}</td></tr></table>`;
+      };
 
       var formGroup = document.createElement('div');
       formGroup.className = 'form-group';
@@ -60,46 +67,48 @@ define([
               document.getElementById('pdf-report-filename').readOnly = true;
               document.getElementById('one-codex-save-button').disabled = true;
               document.getElementById('one-codex-run-all-save-button').disabled = true;
-              alertBox.innerHTML = '<img src="https://app.onecodex.com/images/site-images/spinner.gif" ' +
-                'width="25px">&nbsp;&nbsp; Rendering notebook and uploading. Usually takes less than a minute.';
-              alertBox.className = 'alert alert-info';
+              alertBox.innerHTML = makeSpinnerSVG('&nbsp;&nbsp; Rendering notebook and uploading. Usually takes less than a minute.');
+              alertBox.className = 'alert alert-info no-padding';
 
-              var xhr = new XMLHttpRequest();
-              xhr.open('GET', url);
-              xhr.onload = () => {
-                if (xhr.status === 500) {
-                    alertBox.innerHTML = 'Notebook returned 500 error. Please contact help@onecodex.com for assistance.';
-                    alertBox.className = 'alert alert-danger';
-                    document.getElementById('pdf-report-filename').readOnly = false;
-                    document.getElementById('one-codex-save-button').disabled = false;
-                    document.getElementById('one-codex-run-all-save-button').disabled = false;
-                } else {
-                  try {
-                    var resp_json = JSON.parse(xhr.responseText);
-                  } catch(e) {
-                    var resp_json = {
-                      'status': 500,
-                      'message': 'Unspecified error. Please contact help@onecodex.com for assistance.'
+              // honestly, the only reason to use setTimeout here is so our SVG spinner starts spinning
+              setTimeout(() => {
+                var xhr = new XMLHttpRequest();
+                xhr.open('GET', url);
+                xhr.onload = () => {
+                  if (xhr.status === 500) {
+                      alertBox.innerHTML = 'Notebook returned 500 error. Please contact help@onecodex.com for assistance.';
+                      alertBox.className = 'alert alert-danger';
+                      document.getElementById('pdf-report-filename').readOnly = false;
+                      document.getElementById('one-codex-save-button').disabled = false;
+                      document.getElementById('one-codex-run-all-save-button').disabled = false;
+                  } else {
+                    try {
+                      var resp_json = JSON.parse(xhr.responseText);
+                    } catch(e) {
+                      var resp_json = {
+                        'status': 500,
+                        'message': 'Unspecified error. Please contact help@onecodex.com for assistance.'
+                      }
+                    }
+
+                    if (resp_json['status'] === 500) {
+                      alertBox.innerHTML = 'Upload failed. The server said:<br><br>' + resp_json['message'];
+                      alertBox.className = 'alert alert-danger';
+                      document.getElementById('pdf-report-filename').readOnly = false;
+                      document.getElementById('one-codex-save-button').disabled = false;
+                      document.getElementById('one-codex-run-all-save-button').disabled = false;
+                    } else {
+                      alertBox.innerHTML = 'Export successful! View the report here: <a href="' + 
+                        ONE_CODEX_DOCS_URL + '" target="_blank" class="alert-link">Documents Portal</a>';
+                      alertBox.className = 'alert alert-success';
+                      document.getElementById('one-codex-save-button').className = 'hidden';
+                      document.getElementById('one-codex-run-all-save-button').className = 'hidden';
+                      document.getElementById('one-codex-cancel-button').innerHTML = 'Return to Notebook';
                     }
                   }
-
-                  if (resp_json['status'] === 500) {
-                    alertBox.innerHTML = 'Upload failed. The server said:<br><br>' + resp_json['message'];
-                    alertBox.className = 'alert alert-danger';
-                    document.getElementById('pdf-report-filename').readOnly = false;
-                    document.getElementById('one-codex-save-button').disabled = false;
-                    document.getElementById('one-codex-run-all-save-button').disabled = false;
-                  } else {
-                    alertBox.innerHTML = 'Export successful! View the report here: <a href="' + 
-                      ONE_CODEX_DOCS_URL + '" target="_blank" class="alert-link">Documents Portal</a>';
-                    alertBox.className = 'alert alert-success';
-                    document.getElementById('one-codex-save-button').className = 'hidden';
-                    document.getElementById('one-codex-run-all-save-button').className = 'hidden';
-                    document.getElementById('one-codex-cancel-button').innerHTML = 'Return to Notebook';
-                  }
-                }
-              };
-              xhr.send();
+                };
+                xhr.send();
+              });
             }
           },
           'Run All And Save': {
@@ -110,9 +119,8 @@ define([
               document.getElementById('pdf-report-filename').readOnly = true;
               document.getElementById('one-codex-save-button').disabled = true;
               document.getElementById('one-codex-run-all-save-button').disabled = true;
-              alertBox.innerHTML = '<img src="https://app.onecodex.com/images/site-images/spinner.gif" ' +
-                'width="25px">&nbsp;&nbsp; Executing cells in notebook. Some notebooks may take a few minutes.';
-              alertBox.className = 'alert alert-info';
+              alertBox.innerHTML = makeSpinnerSVG('&nbsp;&nbsp; Executing cells in notebook. Some notebooks may take a few minutes.');
+              alertBox.className = 'alert alert-info no-padding';
 
               IPython.notebook.clear_all_output();
               IPython.notebook.execute_all_cells();


### PR DESCRIPTION
In this PR:

- `onecodex` CLI version is bumped to 0.4.0
- Jupyter notebook is patched to enable export of PDFs to docs portal
- Custom JS is installed in `~/.jupyter/onecodex.js` to support docs portal export modal
- Our fancy animated SVG spinner is installed in `~/.jupyter/one-codex-spinner.svg`
- Older report generation code is removed