### PR TITLE
Add node, vega-cli, and enable server-side rendering of plots

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -194,6 +194,13 @@ COPY notebook/notebook.patch /usr/local/lib/python3.6/site-packages/notebook
 RUN cd /usr/local/lib/python3.6/site-packages/notebook \
     && patch -p0 < notebook.patch
 
+# Install Node and vega-cli for server-side image rendering
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN apt-get -y install nodejs
+RUN npm install -g --unsafe-perm vega-cli@5.4.0 vega-lite@2.7.0
+COPY notebook/vega-cli.patch /usr/lib/node_modules
+RUN cd /usr/lib/node_modules && patch -p0 < vega-cli.patch
+
 # Install One Codex Python lib
 RUN pip install --no-cache onecodex[all]==0.5.4
 

--- a/notebook/vega-cli.patch
+++ b/notebook/vega-cli.patch
@@ -1,0 +1,35 @@
+diff -Naur vega-cli/src/args.js vega-cli-patched/src/args.js
+--- vega-cli/src/args.js	1985-10-26 01:15:00.000000000 -0700
++++ vega-cli/src/args.js	2019-07-18 12:19:39.000000000 -0700
+@@ -39,6 +39,10 @@
+       .describe('h', 'Include XML header and SVG doctype.');
+   }
+ 
++  args.boolean('vl')
++    .alias('vl', 'vegaLite')
++    .describe('vl', 'Compile spec as Vega-Lite.');
++
+   args.number('s')
+     .alias('s', 'scale')
+     .default('s', 1)
+diff -Naur vega-cli/src/render.js vega-cli-patched/src/render.js
+--- vega-cli/src/render.js	1985-10-26 01:15:00.000000000 -0700
++++ vega-cli-patched/src/render.js	2019-07-18 12:19:39.000000000 -0700
+@@ -1,4 +1,5 @@
+ const vega = require('vega'),
++      vl = require('vega-lite'),
+       path = require('path'),
+       args = require('./args'),
+       read = require('./read');
+@@ -44,6 +45,11 @@
+ 
+   // instantiate view and invoke headless render method
+   function render(spec) {
++    // use vega-lite, if specified
++    if (arg.vegaLite) {
++      spec = vl.compile(spec, { logger: vega.logger(loglevel, 'warn') }).spec;
++    }
++
+     const view = new vega.View(vega.parse(spec, config), {
+         loader: vega.loader({baseURL: base}),   // load files from base path
+         logger: vega.logger(loglevel, 'error'), // route all logging to stderr


### PR DESCRIPTION
This PR adds `node` to the notebook docker image, the `vega-cli` package, and applies a patch that allows it to work with `vega-lite` (the JSON schema output by `altair`). This is used by the `onecodex` repo during exports of notebook reports that lack rendered images, but contain Vega JSON.