### PR TITLE
Add Github CI publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish new image version
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+
+env:
+  REPO: quay.io/refgenomics/docker-onecodex-notebook
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to quay.io
+        run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} quay.io --password-stdin
+
+      - name: Extract branch/tag name
+        run: |
+          export TAG="${GITHUB_REF##*/}"
+          # Pushes to the "master" branch are published as "latest" image tag
+          if [ "$TAG" = "master" ]; then
+            export TAG="latest"
+          fi
+          echo "tag=$TAG" >> $GITHUB_ENV
+
+      - name: Build image
+        run: |
+          export DOCKER_BUILDKIT=1
+          docker build \
+            -t ${{env.REPO}}:${{env.tag}} \
+            .
+
+      - name: Publish image
+        run: |
+          docker push ${{env.REPO}}:${{env.tag}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,3 +38,16 @@ jobs:
       - name: Publish image
         run: |
           docker push ${{env.REPO}}:${{env.tag}}
+
+      - name: Notify Slack
+        uses: rtCamp/action-slack-notify@master
+        if: ${{ success() }}
+        env:
+          SLACK_WEBHOOK: "${{ secrets.ENGINEERING_SLACK_WEBHOOK }}"
+          SLACK_CHANNEL: "#ocx-engineering"
+          SLACK_USERNAME: "Github"
+          SLACK_ICON: "https://github.com/quintessence/slack-icons/blob/master/images/docker-logo-slack-icon.png"
+          SLACK_COLOR: "good"
+          SLACK_MESSAGE: "New image *${{env.REPO}}:${{env.tag}}* ready!"
+          SLACK_TITLE: "Docker image bakery"
+        continue-on-error: true


### PR DESCRIPTION
In order to automate publishing docker images, this PR adds a Github CI action which will publish the images in an automated way.
Pushing a new tag will create an image tagged with said tag while pushing to the `master` branch will publish a new verion under the `latest` tag.