### PR TITLE
Add save notebook message handler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN pip install --upgrade pip
 
 # Install awscli
 # IMPORTANT: this is required for saving the notebook to S3
-RUN pip install awscli==1.18.140
+RUN pip install awscli==1.22.55
 
 # Install numpy
 RUN pip install numpy==1.18.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -148,6 +148,9 @@ COPY notebook/one-codex-spinner.svg /home/$NB_USER/.jupyter/custom/
 # Add local files
 COPY notebook/jupyter_notebook_config.py /home/$NB_USER/.jupyter/
 COPY notebook/token_notebook.py /usr/local/bin/token_notebook.py
+COPY notebook/save_message_handler.js /usr/local/share/jupyter/customextensions/
+RUN jupyter nbextension install /usr/local/share/jupyter/customextensions/ \
+    && jupyter nbextension enable customextensions/save_message_handler
 RUN chmod +x /usr/local/bin/token_notebook.py
 
 # Add patch to jupyter notebook for export to One Codex document portal

--- a/notebook/notebook.html
+++ b/notebook/notebook.html
@@ -337,8 +337,8 @@ data-notebook-path="{{notebook_path | urlencode}}"
 {% block script %}
 {{super()}}
 <script type="text/javascript">
-    sys_info = {{sys_info|safe}};
-    iframe_source = "{{iframe_source|default('http://localhost')}}";
+    const sys_info = {{sys_info|safe}};
+    const iframe_source = "{{iframe_source|default('http://localhost')}}";
 </script>
 
 <script src="{{ static_url("components/text-encoding/lib/encoding.js") }}" charset="utf-8"></script>

--- a/notebook/notebook.html
+++ b/notebook/notebook.html
@@ -338,6 +338,7 @@ data-notebook-path="{{notebook_path | urlencode}}"
 {{super()}}
 <script type="text/javascript">
     sys_info = {{sys_info|safe}};
+    iframe_source = "{{iframe_source|default('http://localhost')}}";
 </script>
 
 <script src="{{ static_url("components/text-encoding/lib/encoding.js") }}" charset="utf-8"></script>

--- a/notebook/save_message_handler.js
+++ b/notebook/save_message_handler.js
@@ -7,7 +7,7 @@ define([
         window.addEventListener("message", (event) => {
             const source = iframe_source || "http://localhost";
             if (event.origin !== source) {
-                console.log(`Event from unknown source (${event.origin}) : ${event.data}`);
+                console.error(`Event from unknown source (${event.origin}) : ${event.data}`);
             }
             else {
                 // Message coming from a confirmed source

--- a/notebook/save_message_handler.js
+++ b/notebook/save_message_handler.js
@@ -1,0 +1,24 @@
+define([
+    'base/js/namespace'
+], function(
+    Jupyter
+) {
+    function load_handle_save_notebook_extension() {
+        window.addEventListener("message", (event) => {
+            const source = iframe_source || "http://localhost";
+            if (event.origin !== source) {
+                console.log(`Event from unknown source (${event.origin}) : ${event.data}`);
+            }
+            else {
+                // Message coming from a confirmed source
+                if (event.data === "saveNotebook") {
+                    Jupyter.notebook.save_notebook();
+                }
+            }
+        });
+    }
+
+    return {
+        load_ipython_extension: load_handle_save_notebook_extension
+    };
+});


### PR DESCRIPTION
In order to trigger save notebook from a site embedding the notebook (mainline) with a domain different than the notebook domain, a `postMessage` mechanism needs to be utilised as explained here [link](https://medium.com/@crookse/cross-domain-communication-parent-window-and-child-iframe-aaf90fcb3e26).
This PR introduces the handler side for incoming messages which trigger save notebook action.
The message origin is validated using an `iframe_source` param passed into the notebook jinja template params.