### PR TITLE
Handle wildcards in iframe source

### DIFF
--- a/notebook/save_message_handler.js
+++ b/notebook/save_message_handler.js
@@ -4,9 +4,19 @@ define([
     Jupyter
 ) {
     function load_handle_save_notebook_extension() {
+        // iframe_source examples: "https://localhost", "https://app.onecodex.com https://localhost"
+        // "https://*.onecodex.com https://*.onecodex.cloud"; all those scenarios are supported
+        const source = iframe_source || "http://localhost";
+        const sourceGrouped = source.includes(" ")
+            ? "(" + source.replaceAll(" ", "|") + ")"
+            : source;
+        const rule = new RegExp(sourceGrouped.replaceAll("*", ".*"));
         window.addEventListener("message", (event) => {
-            const source = iframe_source || "http://localhost";
-            if (event.origin !== source) {
+            if (!event.data) {
+                // Events with no data are just ignored
+                return;
+            }
+            if (!rule.test(event.origin)) {
                 console.error(`Event from unknown source (${event.origin}) : ${event.data}`);
             }
             else {


### PR DESCRIPTION
The iframe source param may contain multiple values and wildcard characters.
This PR handles those cases when validating the javascript message sent with `postMessage`.