### PR TITLE
Fix dependency issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,5 +134,8 @@ RUN cd /usr/local/lib/python3.8/site-packages/notebook \
 # RUN chown -R $NB_USER:root /home/$NB_USER && chmod -R u+rw,g+rw /home/$NB_USER
 RUN chown -R $NB_USER:root /home/$NB_USER && find /home/$NB_USER -type d -exec chmod 775 {} \;
 
+# Provide full access to the Python directory to allow for pip installs
+RUN chown -R $NB_USER:root /usr/local/lib/python3.8
+
 # Switch to unprivileged user, jovyan
 USER $NB_USER

--- a/notebook/override.css
+++ b/notebook/override.css
@@ -2,6 +2,10 @@
 This is only required when different pages style the same element differently. This is just
 a hack to deal with our current css styles and no new styling should be added in this file.*/
 
+body {
+  padding: 0 !important;
+}
+
 #ipython-main-app {
     position: relative;
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+awscli==1.22.55
+numpy==1.18.4
+biopython==1.78
+ipywidgets
+jupyter_contrib_nbextensions
+nbconvert==6.5.0
+openpyxl==3.0.3
+xlrd==1.2.0
+statsmodels==0.11.1
+WeasyPrint==54.2
+onecodex[all,reports]==0.10.0
+taxonomy==0.8.1
+widgetsnbextension


### PR DESCRIPTION
New onecodex library introduced some dependency issues which caused a few subtle errors, e.g. invalid notebook display style.
Onecodex library update from a few months ago also introduced PDF export error which remained undetected until now - this PR fixes that as well.