### PR TITLE
Fix dependency issues, add XSRF config

### DIFF
--- a/notebook/jupyter_notebook_config.py
+++ b/notebook/jupyter_notebook_config.py
@@ -11,6 +11,7 @@ c = get_config()
 c.NotebookApp.ip = '0.0.0.0'
 c.NotebookApp.port = 8888
 c.NotebookApp.open_browser = False
+c.NotebookApp.tornado_settings = {"xsrf_cookies": False}
 
 # Prefer JavaScript over SVG when exporting notebooks as HTML--keeps figures interactive
 c.NbConvertBase.display_data_priority = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,13 @@
 awscli==1.22.55
-numpy==1.18.4
-biopython==1.78
+numpy==1.22.3
+scikit-bio==0.5.7
+biopython==1.79
 ipywidgets
 jupyter_contrib_nbextensions
 nbconvert==6.5.0
 openpyxl==3.0.3
 xlrd==1.2.0
-statsmodels==0.11.1
+statsmodels==0.13.2
 WeasyPrint==54.2
 onecodex[all,reports]==0.10.0
 taxonomy==0.8.1


### PR DESCRIPTION
The previous images had an issue with `scikit-bio` not being pinned while `numpy` was - which caused runtime errors.
This PR bumps bio dependencies and pins `scikit-bio` to prevent this from happening in the future.
Also in this PR: setting the XSRF cookie config within the image so that it doesn't need to be explicitly passed in from the app.


## TODOs
- [X] Build and push corresponding docker image